### PR TITLE
PC-149: Fix CircleCI build failures

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 		},
 		"ghcr.io/codeman99/features/circleci-cli:1": {
 			"completions": true,
-			"telemetry": "enable"
+			"telemetry": "disable"
 		},
 		// docker: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /tmp/3479705488_circleci_config.yml.
 		// "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
@@ -34,9 +34,16 @@
 			"azureDnsAutoDetection": true,
 			"installDockerBuildx": true,
 			"installDockerComposeSwitch": true,
-			"disableIp6tables": true,
-			"version": "27.3.1-debian12u1",
-			"dockerDashComposeVersion": "v2"
+			"version": "latest",
+			"dockerDashComposeVersion": "latest"
+		},
+		"ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
+			"allowJqRcVersion": true,
+			"jqVersion": "latest",
+			"yqVersion": "latest",
+			"gojqVersion": "none",
+			"xqVersion": "none",
+			"jaqVersion": "none"
 		}
 	},
 	// "build": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,60 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "openscad-mxe-64bit",
+	"image": "openscad/mxe-x86_64-gui:latest",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cmake-tools",
+				"circleci.circleci"
+			]
+		}
+	},
+	// TODO: Mount /root/openscad_deps from host
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"installDirectlyFromGitHubRelease": true,
+			"version": "latest"
+		},
+		"ghcr.io/codeman99/features/circleci-cli:1": {
+			"completions": true,
+			"telemetry": "enable"
+		},
+		// docker: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /tmp/3479705488_circleci_config.yml.
+		// "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+		// 	"moby": true,
+		// 	"installDockerBuildx": true,
+		// 	"installDockerComposeSwitch": true,
+		// 	"version": "20.10",
+		// 	"dockerDashComposeVersion": "v2"
+		// },
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"moby": true,
+			"azureDnsAutoDetection": true,
+			"installDockerBuildx": true,
+			"installDockerComposeSwitch": true,
+			"disableIp6tables": true,
+			"version": "27.3.1-debian12u1",
+			"dockerDashComposeVersion": "v2"
+		}
+	},
+	// "build": {
+	// 	"dockerfile": "Dockerfile"
+	// }
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "workbench.colorTheme": "GitHub Dark",
+    "cmake.options.statusBarVisibility": "visible"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,10 +416,13 @@ target_link_libraries(OpenSCAD PRIVATE ${LIBXML2_LIBRARIES})
 
 # PartCAD embeds Python Interpreter
 if (ENABLE_PARTCAD OR ENABLE_PYTHON)
-  find_package(Python REQUIRED COMPONENTS Interpreter Development)
-  MESSAGE(STATUS "Python: ${Python_VERSION} dirs=${Python_INCLUDE_DIRS} libs=${Python_LIBRARIES} exec=${Python_EXECUTABLE}}")
-  target_include_directories(OpenSCAD PRIVATE ${Python_INCLUDE_DIRS})
-  target_link_libraries(OpenSCAD PRIVATE ${Python_LIBRARIES})
+  set(Python3_EXECUTABLE "/usr/bin/python3.11")
+  set(Python3_LIBRARY "/usr/lib/x86_64-linux-gnu/libpython3.11.so")
+  set(Python3_INCLUDE_DIR "/usr/include/python3.11")
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+  MESSAGE(STATUS "Python: ${Python_VERSION} dirs=${Python3_INCLUDE_DIR} libs=${Python3_LIBRARY} exec=${Python3_EXECUTABLE}}")
+  target_include_directories(OpenSCAD PRIVATE ${Python3_INCLUDE_DIR} PRIVATE "/usr/include/x86_64-linux-gnu/python3.11" )
+  target_link_libraries(OpenSCAD PRIVATE ${Python3_LIBRARY})
 endif()
 
 if(ENABLE_PYTHON)

--- a/README.md
+++ b/README.md
@@ -303,3 +303,32 @@ Note: Both `cmake --build` and `ctest` accepts a `-j N` argument for distributin
 	#    ...
 	#    ./scripts/release-common.sh -snapshot -mingw64 -v "$OPENSCAD_VERSION"
 	```
+
+    For incremental builds:
+
+    ```bash
+    # This will purge ./build/* and few other "cached" files
+    git clean -ffdx
+    # Less invasive option
+    rm -rf CMakeCache.txt CMakeFiles/
+    ```
+
+    ```bash
+    # python3 -m ensurepip --upgrade
+    apt-get install --yes python3-venv python3-pip # see doc/testing.txt
+    # apt-get install --yes python3-dev
+    export CIRCLE_BRANCH=$(git branch --show-current)
+    # https://en.wikipedia.org/wiki/Fast_inverse_square_root
+    export CIRCLE_BUILD_NUM=1597463007
+    yq '.jobs.openscad-mxe-64bit.steps[].run | select(. != null) | .command' .circleci/config.yml | bash -euxo pipefail -
+    ```
+
+## Roadmap
+
+- [ ] Add Dev Container configuration to extenal repo.
+- [ ] Deal with "test suite venv" error:
+  ```
+  CMake Warning at tests/CMakeLists.txt:109 (message):
+    Failed to setup the test suite venv for VENV_BIN_PATH-NOTFOUND/python.exe
+    See doc/testing.txt for dependency information.
+  ```

--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -182,6 +182,9 @@ fi
 echo "  NUMCPU: $NUMCPU"
 
 cd $DEPLOYDIR
+# -DPython3_EXECUTABLE=/usr/bin/python3.11 \
+# -DPython3_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.11.so \
+# -DPython3_INCLUDE_DIR=/usr/include/python3.11/ \
 CMAKE_CONFIG="${CMAKE_CONFIG}\
  -DCMAKE_BUILD_TYPE=${BUILD_TYPE}\
  -DOPENSCAD_VERSION=${VERSION}\

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -216,7 +216,12 @@ set(OPENSCAD_EXE_ARG "--openscad=${OPENSCAD_BINPATH}")
 # If OpenSCAD was built with support for PartCAD then
 # install PartCAD Python module
 if(ENABLE_PARTCAD)
-  execute_process(COMMAND "${Python3_EXECUTABLE}" -m pip install -U partcad
+execute_process(COMMAND "${Python3_EXECUTABLE}" -m venv /tmp/.venv
+                  RESULT_VARIABLE PARTCAD_INSTALL_RESULT
+                  OUTPUT_VARIABLE PARTCAD_INSTALL_OUTPUT
+                  ERROR_VARIABLE PARTCAD_INSTALL_ERROR)
+
+execute_process(COMMAND /tmp/.venv/bin/pip install -U partcad
                   RESULT_VARIABLE PARTCAD_INSTALL_RESULT
                   OUTPUT_VARIABLE PARTCAD_INSTALL_OUTPUT
                   ERROR_VARIABLE PARTCAD_INSTALL_ERROR)


### PR DESCRIPTION
# Roadmap

- [ ] Deal with `ninja: build stopped: subcommand failed.`
  ```
  [174/275] Building CXX object CMakeFiles/OpenSCAD.dir/src/core/PartCAD.cc.obj
  FAILED: CMakeFiles/OpenSCAD.dir/src/core/PartCAD.cc.obj 
  /mxe/usr/x86_64-pc-linux-gnu/bin/x86_64-w64-mingw32.static.posix-g++ -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DCGAL_DEBUG -DCGAL_USE_CORE=1 -DCGAL_USE_GMPXX -DCGAL_USE_GMPXX=1 -DEIGEN_DONT_ALIGN -DENABLE_CAIRO -DENABLE_CGAL -DENABLE_DBUS -DENABLE_EXPERIMENTAL -DENABLE_HIDAPI -DENABLE_LIB3MF -DENABLE_LIBZIP -DENABLE_MANIFOLD -DENABLE_OPENCSG -DENABLE_PARTCAD -DENABLE_QGAMEPAD -DGLEW_STATIC -DLIBXML_STATIC -DMI_LINK_STATIC -DMI_OVERRIDE -DNOGDI -DOPENCSG_GLEW -DOPENSCAD_COMMIT=b0defc89f -DOPENSCAD_DAY=13 -DOPENSCAD_MONTH=12 -DOPENSCAD_OS=\"Windows\" -DOPENSCAD_SHORTVERSION=2024.12.13 -DOPENSCAD_SNAPSHOT -DOPENSCAD_VERSION=2024.12.13 -DOPENSCAD_YEAR=2024 -DQT_ACCESSIBILITY_SUPPORT_LIB -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_EVENTDISPATCHER_SUPPORT_LIB -DQT_FONTDATABASE_SUPPORT_LIB -DQT_GAMEPAD_LIB -DQT_GUI_LIB -DQT_MULTIMEDIA_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_SVG_LIB -DQT_THEME_SUPPORT_LIB -DQT_WIDGETS_LIB -DQT_WINDOWSUIAUTOMATION_SUPPORT_LIB -DSTACKSIZE=8388608 -DSTATIC_QT_SVG_PLUGIN -DUNICODE -DUSE_GLEW -DUSE_MIMALLOC -DUSE_QOPENGLWIDGET -D_REENTRANT -D_UNICODE -D_USE_MATH_DEFINES -I/workspaces/openscad/mingw64.static.posix -I/workspaces/openscad -I/workspaces/openscad/mingw64.static.posix/OpenSCAD_autogen/include -I/usr/include/python3.11 -I/usr/include/x86_64-linux-gnu/python3.11 -I/workspaces/openscad/src -I/workspaces/openscad/src/ext -I/workspaces/openscad/src/ext/lexertl/include -I/workspaces/openscad/src/ext/libtess2/Include -I/workspaces/openscad/src/core -I/workspaces/openscad/src/core/customizer -I/workspaces/openscad/src/ext/json -I/workspaces/openscad/src/geometry -I/workspaces/openscad/src/geometry/cgal -I/workspaces/openscad/src/geometry/manifold -I/workspaces/openscad/src/glview -I/workspaces/openscad/src/glview/preview -I/workspaces/openscad/src/glview/cgal -I/workspaces/openscad/src/gui -I/workspaces/openscad/src/io -I/workspaces/openscad/src/platform -I/workspaces/openscad/src/utils -I/workspaces/openscad/submodules/manifold/include -I/workspaces/openscad/mingw64.static.posix/submodules/manifold/include -isystem /workspaces/openscad/submodules/mimalloc/include -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/eigen3 -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/harfbuzz -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/glib-2.0 -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/lib/glib-2.0/include -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/libzip -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/freetype2 -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/libxml2 -isystem /workspaces/openscad/src/ext/hidapi -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/cairo -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/pixman-1 -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/include/libpng16 -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtCore -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/./mkspecs/win32-g++ -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtWidgets -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtGui -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtSvg -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtEventDispatcherSupport -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtFontDatabaseSupport -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtThemeSupport -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtAccessibilitySupport -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtWindowsUIAutomationSupport -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtMultimedia -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtNetwork -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtOpenGL -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtConcurrent -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtDBus -isystem /mxe/usr/x86_64-w64-mingw32.static.posix/qt5/include/QtGamepad -frounding-math -Wno-attributes -O3 -DNDEBUG -std=c++17 -frounding-math -DMANIFOLD_CROSS_SECTION -DMANIFOLD_PAR=1 -MD -MT CMakeFiles/OpenSCAD.dir/src/core/PartCAD.cc.obj -MF CMakeFiles/OpenSCAD.dir/src/core/PartCAD.cc.obj.d -o CMakeFiles/OpenSCAD.dir/src/core/PartCAD.cc.obj -c /workspaces/openscad/src/core/PartCAD.cc
  In file included from /usr/include/python3.11/Python.h:12,
                   from /workspaces/openscad/src/core/PartCAD.cc:1:
  /usr/include/python3.11/pyconfig.h:106:3: error: #error unknown multiarch location for pyconfig.h
    106 | # error unknown multiarch location for pyconfig.h
        |   ^~~~~
  In file included from /usr/include/python3.11/pyport.h:4,
                   from /usr/include/python3.11/Python.h:38:
  /usr/include/python3.11/pyconfig.h:106:3: error: #error unknown multiarch location for pyconfig.h
    106 | # error unknown multiarch location for pyconfig.h
        |   ^~~~~
  In file included from /usr/include/python3.11/Python.h:51:
  /usr/include/python3.11/unicodeobject.h:68:2: error: #error Must define SIZEOF_WCHAR_T
     68 | #error Must define SIZEOF_WCHAR_T
        |  ^~~~~
  In file included from /usr/include/python3.11/pythread.h:126,
                   from /usr/include/python3.11/Python.h:89:
  /usr/include/python3.11/cpython/pythread.h:27:5: error: #error "Require native threads. See https://bugs.python.org/issue31370"
     27 | #   error "Require native threads. See https://bugs.python.org/issue31370"
        |     ^~~~~
  /usr/include/python3.11/cpython/unicodeobject.h: In function 'Py_ssize_t PyUnicode_GET_DATA_SIZE(PyObject*)':
  /usr/include/python3.11/unicodeobject.h:71:25: error: 'SIZEOF_WCHAR_T' was not declared in this scope; did you mean 'SIZEOF_PY_HASH_T'?
     71 | #define Py_UNICODE_SIZE SIZEOF_WCHAR_T
        |                         ^~~~~~~~~~~~~~
  /usr/include/python3.11/cpython/unicodeobject.h:672:37: note: in expansion of macro 'Py_UNICODE_SIZE'
    672 |     return PyUnicode_GET_SIZE(op) * Py_UNICODE_SIZE;
        |                                     ^~~~~~~~~~~~~~~
  /usr/include/python3.11/cpython/pythread.h: At global scope:
  /usr/include/python3.11/cpython/pythread.h:36:5: error: 'NATIVE_TSS_KEY_T' does not name a type
     36 |     NATIVE_TSS_KEY_T _key;
        |     ^~~~~~~~~~~~~~~~
  /workspaces/openscad/src/core/PartCAD.cc: In function 'void logPartCADError()':
  /workspaces/openscad/src/core/PartCAD.cc:48:19: error: 'PyErr_GetRaisedException' was not declared in this scope; did you mean 'PyErr_GetHandledException'?
     48 |   pExcValue.reset(PyErr_GetRaisedException());
        |                   ^~~~~~~~~~~~~~~~~~~~~~~~
        |                   PyErr_GetHandledException
  [177/275] Building CXX object CMakeFiles/OpenSCAD.dir/src/glview/fbo.cc.obj
  ```
- [ ] Move Dev Container configuration to external repo.
- [ ] Deal with "test suite venv" error:
  ```
  CMake Warning at tests/CMakeLists.txt:109 (message):
    Failed to setup the test suite venv for VENV_BIN_PATH-NOTFOUND/python.exe
    See doc/testing.txt for dependency information.
  ```

# Related PRs

- https://github.com/openscad/openscad/pull/5476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a development container configuration for enhanced development workflows.
	- Added Visual Studio Code settings for a customized user interface.
	- Updated README with instructions for running CI workflows locally and a roadmap for future tasks.
  
- **Bug Fixes**
	- Improved error handling in the release script and testing environment setup.

- **Documentation**
	- Enhanced README with clearer instructions for local development and CI processes.

- **Chores**
	- Updated scripts for better functionality and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->